### PR TITLE
Chainpoint-node -> New/update Registration POST|PUT /nodes -> Remove Port # from public_uri provided in request

### DIFF
--- a/node-api-service/lib/endpoints/nodes.js
+++ b/node-api-service/lib/endpoints/nodes.js
@@ -163,7 +163,7 @@ async function postNodeV1Async (req, res, next) {
 
     let parsedURI = url.parse(req.params.public_uri)
 
-    return `${protocol}//${parsedURI.hostname}`
+    return `${parsedURI.protocol}//${parsedURI.hostname}`
   })()
   // if an public_uri is provided, it must be valid
   if (lowerCasedPublicUri && !_.isEmpty(lowerCasedPublicUri)) {
@@ -296,7 +296,7 @@ async function putNodeV1Async (req, res, next) {
 
     let parsedURI = url.parse(req.params.public_uri)
 
-    return `${protocol}//${parsedURI.hostname}`
+    return `${parsedURI.protocol}//${parsedURI.hostname}`
   })()
   // if an public_uri is provided, it must be valid
   if (lowerCasedPublicUri && !_.isEmpty(lowerCasedPublicUri)) {

--- a/node-api-service/lib/endpoints/nodes.js
+++ b/node-api-service/lib/endpoints/nodes.js
@@ -158,6 +158,7 @@ async function postNodeV1Async (req, res, next) {
   }
 
   // Return formatted Public URI, omit port number as nodes are only allowed to run on default: Port 80
+  // using url.parse() will implicitly lowercase the uri provided
   let lowerCasedPublicUri = (() => {
     if (!req.params.public_uri) return null
 
@@ -178,6 +179,8 @@ async function postNodeV1Async (req, res, next) {
     if (ip.isPrivate(parsedPublicUri.hostname)) return next(new restify.InvalidArgumentError('public_uri hostname must not be a private IP'))
     // disallow 0.0.0.0
     if (parsedPublicUri.hostname === '0.0.0.0') return next(new restify.InvalidArgumentError('0.0.0.0 not allowed in public_uri'))
+    // disallow any port that is not 80
+    if (url.parse(req.params.public_uri).port && url.parse(req.params.public_uri).port !== '80') return next(new restify.InvalidArgumentError('public_uri hostname must specify port 80 or omit the port number to have it be implicitly set to 80'))
   }
 
   try {

--- a/node-api-service/lib/endpoints/nodes.js
+++ b/node-api-service/lib/endpoints/nodes.js
@@ -157,7 +157,14 @@ async function postNodeV1Async (req, res, next) {
     lowerCasedTntAddrParam = req.params.tnt_addr.toLowerCase()
   }
 
-  let lowerCasedPublicUri = req.params.public_uri ? req.params.public_uri.toString().toLowerCase() : null
+  // Return formatted Public URI, omit port number as nodes are only allowed to run on default: Port 80
+  let lowerCasedPublicUri = (() => {
+    if (!req.params.public_uri) return null
+
+    let parsedURI = url.parse(req.params.public_uri)
+
+    return `${protocol}//${parsedURI.hostname}`
+  })()
   // if an public_uri is provided, it must be valid
   if (lowerCasedPublicUri && !_.isEmpty(lowerCasedPublicUri)) {
     if (!validUrl.isHttpUri(lowerCasedPublicUri)) {
@@ -283,7 +290,14 @@ async function putNodeV1Async (req, res, next) {
     return next(new restify.InvalidArgumentError('invalid JSON body, invalid hmac'))
   }
 
-  let lowerCasedPublicUri = req.params.public_uri ? req.params.public_uri.toString().toLowerCase() : null
+  // Return formatted Public URI, omit port number as nodes are only allowed to run on default: Port 80
+  let lowerCasedPublicUri = (() => {
+    if (!req.params.public_uri) return null
+
+    let parsedURI = url.parse(req.params.public_uri)
+
+    return `${protocol}//${parsedURI.hostname}`
+  })()
   // if an public_uri is provided, it must be valid
   if (lowerCasedPublicUri && !_.isEmpty(lowerCasedPublicUri)) {
     if (!validUrl.isHttpUri(lowerCasedPublicUri)) {


### PR DESCRIPTION
This PR is in response to being able to successfully register using the same IP Address + different port. `node-api-service -> nodes endpoint` does not strip out port # prior to this PR. The public_uri provided by the node is mark tainted if it is not a valid HTTP Address and is treated as a new entry given that the sanitized uri's always keep the port number specified (if explicitly specified). This change now strips the port # if explicitly provided within public_uri. This change is done for both POST|PUT /nodes

Pending:
- Change needs to be tested, chainpoint-services is not successfully running on my machine. When I change the `CHAINPOINT_CORE_API_BASE_URI=http://127.0.0.1` env variable for chainpoint-node it is getting a connection refused error. 
- Need help finalizing local dev environment setup for chainpoint-node to communicate with local chainpoint-services

https://www.pivotaltracker.com/n/projects/1990249/stories/159307973

Chainpoint-node-src feature needs to be merged simultaneously (https://github.com/chainpoint/chainpoint-node-src/tree/feature/node-uri-port-check-%23159307973)