### PR TITLE
Audits...

### DIFF
--- a/node-audit-producer-service/server.js
+++ b/node-audit-producer-service/server.js
@@ -103,7 +103,7 @@ async function auditNodesAsync (opts = { e2eAudit: false }) {
       let taskHandlerArgs = (function () {
         let defaultRetryCount = 0
 
-        if (opts.e2eAudit === true) return [publicNodeReadyForAudit.public_uri, defaultRetryCount]
+        if (opts.e2eAudit === true) return [publicNodeReadyForAudit, defaultRetryCount]
         else return [ publicNodeReadyForAudit, activePublicNodeCount ]
       })()
 
@@ -425,10 +425,10 @@ function setPerformNodeAuditTrigger () {
 function setPerformE2ENodeAuditTrigger () {
   let currentDay = new Date().getUTCDate()
 
-  heart.createEvent(5, async function (count, last) {
+  heart.createEvent(5, async function (count, last) { // --> DEVELOPMENT TESTING:(5)
     let now = new Date()
     // Run e2eAuditNodesAsync() once a day, and only if we are on a new day
-    if (now.getUTCDate() !== currentDay && IS_LEADER) {
+    if (now.getUTCDate() !== currentDay && IS_LEADER) { // --> DEVELOPMENT TESTING:(if (IS_LEADER) {)
       currentDay = now.getUTCDate()
       try {
         await auditNodesAsync({ e2eAudit: true })
@@ -465,7 +465,10 @@ async function setTimedTriggeredEventsAsync () {
 
   setGenerateNewChallengeTrigger()
   setPerformNodeAuditTrigger()
-  setPerformE2ENodeAuditTrigger()
+  // Do not invoke E2E Audit trigger if audits are disabled
+  if (env.E2E_AUDIT_ENABLED === 'yes') {
+    setPerformE2ENodeAuditTrigger()
+  }
   setPerformCreditTopoffTrigger()
 }
 

--- a/node-audit-producer-service/server.js
+++ b/node-audit-producer-service/server.js
@@ -116,7 +116,7 @@ async function auditNodesAsync (opts = { e2eAudit: false }) {
       console.error(`Could not enqueue ${(opts.e2eAudit === true) ? 'e2e_' : ''}audit_public_node task : ${error.message}`)
     }
   }
-  console.log(`${(opts.e2eAudit === true) ? 'E2e ' : ''}Audit public tasks queued for task-handler`)
+  console.log(`${(opts.e2eAudit === true) ? 'E2E ' : ''}Audit public tasks queued for task-handler`)
 
   // Short circuit this function if this is an E2E Audit. At this point, we have queued all Public nodes that will be
   // processed by 'e2e_audit_public_node' and have no need to perform an e2e audit of private nodes.

--- a/node-audit-producer-service/server.js
+++ b/node-audit-producer-service/server.js
@@ -425,10 +425,10 @@ function setPerformNodeAuditTrigger () {
 function setPerformE2ENodeAuditTrigger () {
   let currentDay = new Date().getUTCDate()
 
-  heart.createEvent(5, async function (count, last) { // --> DEVELOPMENT TESTING:(5)
+  heart.createEvent(5, async function (count, last) {
     let now = new Date()
     // Run e2eAuditNodesAsync() once a day, and only if we are on a new day
-    if (now.getUTCDate() !== currentDay && IS_LEADER) { // --> DEVELOPMENT TESTING:(if (IS_LEADER) {)
+    if (now.getUTCDate() !== currentDay && IS_LEADER) {
       currentDay = now.getUTCDate()
       try {
         await auditNodesAsync({ e2eAudit: true })

--- a/node-lib/lib/connections.js
+++ b/node-lib/lib/connections.js
@@ -8,7 +8,7 @@ const utils = require('./utils.js')
  * @param {function} onReady - Function to call with commands to execute when `ready` event fires
  * @param {function} onError - Function to call with commands to execute  when `error` event fires
  */
-function openRedisConnection(redisURIs, onReady, onError, debug) {
+function openRedisConnection (redisURIs, onReady, onError, debug) {
   const Redis = require('ioredis')
 
   let redisURIList = redisURIs.split(',')
@@ -61,7 +61,7 @@ function openRedisConnection(redisURIs, onReady, onError, debug) {
 /**
  * Initializes the connection to the Resque queue when Redis is ready
  */
-async function initResqueQueueAsync(redisClient, namespace, debug) {
+async function initResqueQueueAsync (redisClient, namespace, debug) {
   const nodeResque = require('node-resque')
   const exitHook = require('exit-hook')
   var connectionDetails = { redis: redisClient }
@@ -82,7 +82,7 @@ async function initResqueQueueAsync(redisClient, namespace, debug) {
 /**
  * Initializes and configures the connection to the Resque worker when Redis is ready
  */
-async function initResqueWorkerAsync(redisClient, namespace, queues, minTasks, maxTasks, taskTimeout, jobs, setMWHandlers, debug) {
+async function initResqueWorkerAsync (redisClient, namespace, queues, minTasks, maxTasks, taskTimeout, jobs, setMWHandlers, debug) {
   const nodeResque = require('node-resque')
   const exitHook = require('exit-hook')
   var connectionDetails = { redis: redisClient }
@@ -109,10 +109,25 @@ async function initResqueWorkerAsync(redisClient, namespace, queues, minTasks, m
   logMessage(`Resque worker connection established for queues ${JSON.stringify(queues)}`, debug, 'general')
 }
 
+async function initResqueSchedulerAsync (redisClient, setSchedulerHandlers, debug) {
+  const nodeResque = require('node-resque')
+  let connectionDetails = { redis: redisClient }
+
+  // Start Resqueue Scheduler for delayed Jobs
+  const scheduler = new nodeResque.Scheduler({connection: connectionDetails})
+  await scheduler.connect()
+
+  setSchedulerHandlers(scheduler)
+
+  scheduler.start()
+
+  logMessage(`Resque Scheduler connection established for queue(s)`, debug, 'general')
+}
+
 /**
  * Opens a storage connection
  **/
-async function openStorageConnectionAsync(modelSqlzArray, debug) {
+async function openStorageConnectionAsync (modelSqlzArray, debug) {
   let dbConnected = false
   while (!dbConnected) {
     try {
@@ -135,7 +150,7 @@ async function openStorageConnectionAsync(modelSqlzArray, debug) {
  *
  * @param {string} connectionString - The connection URI for the RabbitMQ instance
  */
-async function openStandardRMQConnectionAsync(amqpClient, connectURI, queues, prefetchCount, consumeObj, onInit, onClose, debug) {
+async function openStandardRMQConnectionAsync (amqpClient, connectURI, queues, prefetchCount, consumeObj, onInit, onClose, debug) {
   let rmqConnected = false
   while (!rmqConnected) {
     try {
@@ -172,14 +187,14 @@ async function openStandardRMQConnectionAsync(amqpClient, connectURI, queues, pr
 }
 
 // Initializes and returns a consul client object
-function initConsul(consulClient, host, port, debug) {
+function initConsul (consulClient, host, port, debug) {
   let consul = consulClient({ host: host, port: port })
   logMessage('Consul connection established', debug, 'general')
   return consul
 }
 
 // Instruct REST server to begin listening for request
-async function listenRestifyAsync(server, port, debug) {
+async function listenRestifyAsync (server, port, debug) {
   return new Promise((resolve, reject) => {
     server.listen(port, (err) => {
       if (err) return reject(err)
@@ -190,7 +205,7 @@ async function listenRestifyAsync(server, port, debug) {
 }
 
 // Performs a leader election across all instances using the given leader key
-function performLeaderElection(electorClient, leaderKey, host, port, id, onElect, onError, debug) {
+function performLeaderElection (electorClient, leaderKey, host, port, id, onElect, onError, debug) {
   const uuidv1 = require('uuid/v1')
   let clientToken = uuidv1()
   let leaderElectionConfig = {
@@ -216,7 +231,7 @@ function performLeaderElection(electorClient, leaderKey, host, port, id, onElect
 }
 
 // This initializes all the consul watches
-function startConsulWatches(consul, watches, defaults, debug) {
+function startConsulWatches (consul, watches, defaults, debug) {
   logMessage('starting watches', debug, 'general')
 
   // Process any new watches to be initialized
@@ -254,7 +269,7 @@ function startConsulWatches(consul, watches, defaults, debug) {
   }
 }
 
-function startIntervals(intervals, debug) {
+function startIntervals (intervals, debug) {
   logMessage('starting intervals', debug, 'general')
 
   intervals.forEach((interval) => {
@@ -265,7 +280,7 @@ function startIntervals(intervals, debug) {
 
 // SUPPORT FUNCTIONS ****************
 
-async function cleanUpWorkersAndRequequeJobsAsync(nodeResque, connectionDetails, taskTimeout, debug) {
+async function cleanUpWorkersAndRequequeJobsAsync (nodeResque, connectionDetails, taskTimeout, debug) {
   const queue = new nodeResque.Queue({ connection: connectionDetails })
   await queue.connect()
   // Delete stuck workers and move their stuck job to the failed queue
@@ -292,7 +307,7 @@ async function cleanUpWorkersAndRequequeJobsAsync(nodeResque, connectionDetails,
   }
 }
 
-function logMessage(message, debug, msgType) {
+function logMessage (message, debug, msgType) {
   if (debug && debug[msgType]) {
     debug[msgType](message)
   } else {
@@ -304,6 +319,7 @@ module.exports = {
   openRedisConnection: openRedisConnection,
   initResqueQueueAsync: initResqueQueueAsync,
   initResqueWorkerAsync: initResqueWorkerAsync,
+  initResqueSchedulerAsync: initResqueSchedulerAsync,
   openStorageConnectionAsync: openStorageConnectionAsync,
   openStandardRMQConnectionAsync: openStandardRMQConnectionAsync,
   initConsul: initConsul,

--- a/node-lib/lib/models/RegisteredNode.js
+++ b/node-lib/lib/models/RegisteredNode.js
@@ -125,6 +125,24 @@ var RegisteredNode = sequelize.define(env.COCKROACH_REG_NODE_TABLE_NAME,
       type: Sequelize.STRING,
       field: 'created_from_ip',
       allowNull: true
+    },
+    verifyE2EPassedAt: {
+      comment: 'The time the audit was performed, in MS since EPOCH.',
+      type: Sequelize.INTEGER, // is 64 bit in CockroachDB
+      validate: {
+        isInt: true
+      },
+      field: 'verify_e2e_passed_at',
+      allowNull: true
+    },
+    verifyE2EFailedAt: {
+      comment: 'The time the audit was performed, in MS since EPOCH.',
+      type: Sequelize.INTEGER, // is 64 bit in CockroachDB
+      validate: {
+        isInt: true
+      },
+      field: 'verify_e2e_failed_at',
+      allowNull: true
     }
   },
   {

--- a/node-lib/lib/parse-env.js
+++ b/node-lib/lib/parse-env.js
@@ -164,6 +164,8 @@ let envDefinitions = {
   NEW_AUDIT_CHALLENGES_PER_HOUR: validateFactorOfSixty({ default: 2, desc: 'The number of times per hour to generate new audit challenges, defaults to 2, must be a factor of 60, no greater than 20' }),
   NODE_AUDIT_ROUNDS_PER_HOUR: validateFactorOfSixtyUpToSixty({ default: 2, desc: 'The number of times per hour to perform Node audit rounds, defaults to 60, must be a factor of 60' }),
   AUDIT_PRODUCER_LEADER_KEY: envalid.str({ default: 'service/audit-producer/leader/lock', desc: 'Key used for acquiring audit producer process leadership locks' }),
+  E2E_AUDIT_ENABLED: envalid.str({ default: 'no', desc: 'E2E Audits enabled. Defaults to "no"' }),
+  E2E_AUDIT_SCORING_ENABLED: envalid.str({ default: 'no', desc: 'Determine whether E2E Audit scoring is enabled. If, set to "yes" E2E Audits will affect a nodes audit score. Defaults to "no"' }),
 
   // Task accumulator specific variables
   RMQ_PREFETCH_COUNT_TASK_ACC: envalid.num({ default: 0, desc: 'The maximum number of messages sent over the channel that can be awaiting acknowledgement, 0 = no limit' }),

--- a/node-task-accumulator-service/server.js
+++ b/node-task-accumulator-service/server.js
@@ -180,7 +180,7 @@ async function drainAuditScoreUpdatePoolAsync () {
       let scoreUpdateJSON = pendingUpdateObjs.map((item) => item.scoreUpdateJSON)
       // update audit scores in the database
       try {
-        await taskQueue.enqueue('task-handler-queue', `update_audit_score_items`, [scoreUpdateJSON, false])
+        await taskQueue.enqueue('task-handler-queue', `update_audit_score_items`, [scoreUpdateJSON])
         debug.updateAuditScore(`${scoreUpdateJSON.length} audit score items queued for updating`)
 
         // This batch has been submitted to task handler successfully
@@ -218,7 +218,7 @@ async function drainE2EAuditScoreUpdatePoolAsync () {
       let scoreUpdateJSON = pendingUpdateObjs.map((item) => item.scoreUpdateJSON)
       // update audit scores in the database
       try {
-        await taskQueue.enqueue('task-handler-queue', `update_e2e_audit_score_items`, [scoreUpdateJSON, true])
+        await taskQueue.enqueue('task-handler-queue', `update_e2e_audit_score_items`, [scoreUpdateJSON])
         debug.updateAuditScore(`${scoreUpdateJSON.length} E2E audit score items queued for updating`)
 
         // This batch has been submitted to task handler successfully

--- a/node-task-accumulator-service/server.js
+++ b/node-task-accumulator-service/server.js
@@ -32,6 +32,7 @@ debugPkg.log = console.info.bind(console)
 
 let AUDIT_LOG_WRITE_POOL = []
 let AUDIT_SCORE_UPDATE_POOL = []
+let E2E_AUDIT_SCORE_UPDATE_POOL = []
 
 // Variable indicating if audit log write accumulation pool is currently being drained
 let AUDIT_LOG_WRITE_POOL_DRAINING = false
@@ -42,8 +43,11 @@ let auditLogWriteBatchSize = 500
 // Variable indicating if update node audit score accumulation pool is currently being drained
 let AUDIT_SCORE_UPDATE_POOL_DRAINING = false
 
+// Variable indicating if update E2E node audit score accumulation pool is currently being drained
+let E2E_AUDIT_SCORE_UPDATE_POOL_DRAINING = false
+
 // The number of items to include in a single batch node audit score update (insert on conflict update) command
-let auditScoreUpdateBatchSize = 1000
+let auditScoreUpdateBatchSize = 1000 // --> DEVELOPMENT TESTING:(1)
 
 // The channel used for all amqp communication
 // This value is set once the connection has been established
@@ -73,6 +77,11 @@ function processMessage (msg) {
         // Consumes an audit score update message from the task handler
         // accumulates audit score update tasks and issues batch to task handler
         consumeUpdateAuditScoreMessageAsync(msg)
+        break
+      case 'update_node_e2e_audit_score':
+        // Consumes an audit score update message from the task handler
+        // accumulates audit score update tasks and issues batch to task handler
+        consumeUpdateE2EAuditScoreMessageAsync(msg)
         break
       default:
         // This is an unknown state type
@@ -106,6 +115,19 @@ async function consumeUpdateAuditScoreMessageAsync (msg) {
       msg: msg
     }
     AUDIT_SCORE_UPDATE_POOL.push(scoreUpdateObj)
+  }
+}
+
+async function consumeUpdateE2EAuditScoreMessageAsync (msg) {
+  if (msg !== null) {
+    let scoreUpdateJSON = msg.content.toString()
+
+    // add msg to the scoreUpdate object so that we can ack it later
+    let scoreUpdateObj = {
+      scoreUpdateJSON: scoreUpdateJSON,
+      msg: msg
+    }
+    E2E_AUDIT_SCORE_UPDATE_POOL.push(scoreUpdateObj)
   }
 }
 
@@ -158,7 +180,7 @@ async function drainAuditScoreUpdatePoolAsync () {
       let scoreUpdateJSON = pendingUpdateObjs.map((item) => item.scoreUpdateJSON)
       // update audit scores in the database
       try {
-        await taskQueue.enqueue('task-handler-queue', `update_audit_score_items`, [scoreUpdateJSON])
+        await taskQueue.enqueue('task-handler-queue', `update_audit_score_items`, [scoreUpdateJSON, false])
         debug.updateAuditScore(`${scoreUpdateJSON.length} audit score items queued for updating`)
 
         // This batch has been submitted to task handler successfully
@@ -180,6 +202,44 @@ async function drainAuditScoreUpdatePoolAsync () {
     }
 
     AUDIT_SCORE_UPDATE_POOL_DRAINING = false
+  }
+}
+
+async function drainE2EAuditScoreUpdatePoolAsync () {
+  if (!E2E_AUDIT_SCORE_UPDATE_POOL_DRAINING && amqpChannel != null) {
+    E2E_AUDIT_SCORE_UPDATE_POOL_DRAINING = true
+
+    let currentPendingUpdateCount = E2E_AUDIT_SCORE_UPDATE_POOL.length
+    let updateBatchesNeeded = Math.ceil(currentPendingUpdateCount / auditScoreUpdateBatchSize)
+
+    if (currentPendingUpdateCount > 0) debug.updateAuditScore(`${currentPendingUpdateCount} pending audit score updates currently in pool`)
+    for (let x = 0; x < updateBatchesNeeded; x++) {
+      let pendingUpdateObjs = E2E_AUDIT_SCORE_UPDATE_POOL.splice(0, auditScoreUpdateBatchSize)
+      let scoreUpdateJSON = pendingUpdateObjs.map((item) => item.scoreUpdateJSON)
+      // update audit scores in the database
+      try {
+        await taskQueue.enqueue('task-handler-queue', `update_e2e_audit_score_items`, [scoreUpdateJSON, true])
+        debug.updateAuditScore(`${scoreUpdateJSON.length} E2E audit score items queued for updating`)
+
+        // This batch has been submitted to task handler successfully
+        // ack consumption of all original messages part of this batch
+        pendingUpdateObjs.forEach((item) => {
+          if (item.msg !== null) {
+            amqpChannel.ack(item.msg)
+          }
+        })
+      } catch (error) {
+        console.error(`Could not enqueue update task : ${error.message}`)
+        // nack consumption of all original messages part of this batch
+        pendingUpdateObjs.forEach((item) => {
+          if (item.msg !== null) {
+            amqpChannel.nack(item.msg)
+          }
+        })
+      }
+    }
+
+    E2E_AUDIT_SCORE_UPDATE_POOL_DRAINING = false
   }
 }
 
@@ -234,7 +294,8 @@ async function initResqueQueueAsync () {
 function startIntervals () {
   let intervals = [
     { function: drainAuditLogWritePoolAsync, ms: 1000 },
-    { function: drainAuditScoreUpdatePoolAsync, ms: 1000 }
+    { function: drainAuditScoreUpdatePoolAsync, ms: 1000 },
+    { function: drainE2EAuditScoreUpdatePoolAsync, ms: 1000 }
   ]
   connections.startIntervals(intervals, debug)
 }

--- a/node-task-handler-service/package.json
+++ b/node-task-handler-service/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "amqplib": "^0.5.2",
     "async-retry": "^1.2.1",
+    "chainpoint-parse": "^3.1.2",
     "consul": "^0.30.0",
     "debug": "^3.1.0",
     "envalid": "^4.1.4",

--- a/node-task-handler-service/package.json
+++ b/node-task-handler-service/package.json
@@ -16,6 +16,8 @@
     "envalid": "^4.1.4",
     "exit-hook": "^1.1.1",
     "ioredis": "^3.2.2",
+    "lodash": "^4.17.11",
+    "moment": "^2.22.2",
     "node-resque": "^5.4.1",
     "object-hash": "^1.3.0",
     "request": "^2.85.0",
@@ -24,6 +26,7 @@
     "sequelize": "^4.35.2",
     "sequelize-cockroachdb": "https://github.com/cockroachdb/sequelize-cockroachdb.git#f6b15cfaf23c17882e4b813a4dfc9758a77aa5a9",
     "tweetnacl": "^1.0.0",
-    "tweetnacl-util": "^0.15.0"
+    "tweetnacl-util": "^0.15.0",
+    "uuid-time": "^1.0.0"
   }
 }

--- a/node-task-handler-service/server.js
+++ b/node-task-handler-service/server.js
@@ -106,6 +106,7 @@ const primaryTaskJobs = {
   // tasks from the audit producer service
   'audit_public_node': Object.assign({ perform: performAuditPublicAsync }, pluginOptions),
   'audit_private_node': Object.assign({ perform: performAuditPrivateAsync }, pluginOptions),
+  'e2e_audit_public_node': Object.assign({ perform: performE2EAuditPublicAsync }, pluginOptions),
   'prune_audit_log_ids': Object.assign({ perform: pruneAuditLogsByIdsAsync }, pluginOptions),
   'write_audit_log_items': Object.assign({ perform: writeAuditLogItemsAsync }, pluginOptions),
   'update_audit_score_items': Object.assign({ perform: updateAuditScoreItemsAsync }, pluginOptions),
@@ -306,6 +307,13 @@ async function performAuditPublicAsync (nodeData, activeNodeCount) {
   await addAuditToLogAsync(tntAddr, publicUri, configResultTime, publicIPPass, nodeMSDelta, timePass, calStatePass, minCreditsPass, nodeVersion, nodeVersionPass, tntBalanceGrains, tntBalancePass)
 
   return `Public Audit complete for ${tntAddr} at ${publicUri} : Pass = ${publicIPPass && timePass && calStatePass && minCreditsPass && nodeVersionPass && tntBalancePass}`
+}
+
+async function performE2EAuditPublicAsync (nodeData, activeNodeCount) {
+  let tntAddr = nodeData.tnt_addr
+  let publicUri = nodeData.public_uri
+
+  // TODO: Hash submission
 }
 
 async function performAuditPrivateAsync (nodeData) {

--- a/node-task-handler-service/server.js
+++ b/node-task-handler-service/server.js
@@ -490,7 +490,7 @@ async function performE2EAuditPublicProofRetrievalAsync (tntAddr, publicUri, has
           [tntAddr, publicUri, hashIdNode, hash, (retryCount + 1)]
         )
 
-        return `E2E Audit Hash Retrieval completed for ${tntAddr} at ${publicUri} for hash=${hash}`
+        return `E2E Audit Hash Retrieval re-queue completed for ${tntAddr} at ${publicUri} for hash=${hash}`
       } catch (error) {
         console.error(`Could not re-enqueue e2e_audit_public_node_proof_retrieval task : ${error.message}`)
 
@@ -552,7 +552,7 @@ async function performE2EAuditPublicProofVerificationAsync (tntAddr, publicUri, 
           [tntAddr, publicUri, hashIdNode, hash, base64EncodedProof, (retryCount + 1)]
         )
 
-        return `E2E Audit Proof Verification queued for ${tntAddr} at ${publicUri} for hash=${hash}`
+        return `E2E Audit Proof Verification re-queued for ${tntAddr} at ${publicUri} for hash=${hash}`
       } catch (error) {
         console.error(`Could not re-enqueue e2e_audit_public_node_proof_verification task : ${error.message}`)
 

--- a/node-task-handler-service/yarn.lock
+++ b/node-task-handler-service/yarn.lock
@@ -452,6 +452,10 @@ lodash@^4.13.1, lodash@^4.17.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
 meant@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.0.tgz#cb6286e3b7af9315f16118fdc224726ed38074bb"
@@ -475,6 +479,10 @@ moment-timezone@^0.5.14:
 "moment@>= 2.9.0", moment@^2.20.0:
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
+
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 ms@2.0.0:
   version "2.0.0"
@@ -783,6 +791,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
 tweetnacl@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.0.tgz#713d8b818da42068740bf68386d0479e66fc8a7b"
+
+uuid-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/uuid-time/-/uuid-time-1.0.0.tgz#8bb18fa7089987ef25b0c4047190133cfa3a14c6"
 
 uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"

--- a/node-task-handler-service/yarn.lock
+++ b/node-task-handler-service/yarn.lock
@@ -101,6 +101,28 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+chainpoint-binary@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/chainpoint-binary/-/chainpoint-binary-4.0.1.tgz#25876b35096c61a060c7abf45acebf9564bacd22"
+  dependencies:
+    chainpoint-proof-json-schema "^1.0.0"
+    msgpack-lite "^0.1.26"
+    pako "^1.0.5"
+
+chainpoint-parse@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/chainpoint-parse/-/chainpoint-parse-3.1.2.tgz#498d8a2ea702ca74430371fff155026fa8d509dd"
+  dependencies:
+    chainpoint-binary "^4.0.0"
+    chainpoint-proof-json-schema "^1.0.0"
+    js-sha3 "^0.5.7"
+
+chainpoint-proof-json-schema@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chainpoint-proof-json-schema/-/chainpoint-proof-json-schema-1.0.1.tgz#b933ab0116b94789f053b6a2340e57c4f514f9c0"
+  dependencies:
+    is-my-json-valid "^2.16.0"
+
 chalk@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
@@ -213,6 +235,10 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+event-lite@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.2.tgz#838a3e0fdddef8cc90f128006c8e55a4e4e4c11b"
+
 exit-hook@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -252,6 +278,18 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
+
+generate-function@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  dependencies:
+    is-property "^1.0.2"
+
+generate-object-property@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  dependencies:
+    is-property "^1.0.0"
 
 generic-pool@2.4.3:
   version "2.4.3"
@@ -303,6 +341,10 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+ieee754@^1.1.8:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+
 inflection@1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
@@ -310,6 +352,10 @@ inflection@1.12.0:
 inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+int64-buffer@^0.1.9:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
 
 ioredis@^3.2.2:
   version "3.2.2"
@@ -343,6 +389,24 @@ is-bluebird@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-bluebird/-/is-bluebird-1.0.2.tgz#096439060f4aa411abee19143a84d6a55346d6e2"
 
+is-my-ip-valid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
+
+is-my-json-valid@^2.16.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz#8fd6e40363cd06b963fa877d444bfb5eddc62175"
+  dependencies:
+    generate-function "^2.0.0"
+    generate-object-property "^1.1.0"
+    is-my-ip-valid "^1.0.0"
+    jsonpointer "^4.0.0"
+    xtend "^4.0.0"
+
+is-property@^1.0.0, is-property@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -351,9 +415,17 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
+isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+js-sha3@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
 
 js-string-escape@1.0.1:
   version "1.0.1"
@@ -374,6 +446,10 @@ json-schema@0.2.3:
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
+jsonpointer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -488,6 +564,15 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+msgpack-lite@^0.1.26:
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/msgpack-lite/-/msgpack-lite-0.1.26.tgz#dd3c50b26f059f25e7edee3644418358e2a9ad89"
+  dependencies:
+    event-lite "^0.1.1"
+    ieee754 "^1.1.8"
+    int64-buffer "^0.1.9"
+    isarray "^1.0.0"
+
 node-resque@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/node-resque/-/node-resque-5.4.1.tgz#284e57a30162f59c8942bc3919d35eb5696d3a7a"
@@ -509,6 +594,10 @@ object-hash@^1.3.0:
 packet-reader@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-0.3.1.tgz#cd62e60af8d7fea8a705ec4ff990871c46871f27"
+
+pako@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
 
 papi@^0.27.0:
   version "0.27.0"


### PR DESCRIPTION
Extended Audits to include e2e capability.

## Testing
* Local testing was done with 5 Nodes (2 DO nodes)
* All values were being properly updated as expected as a result of starting/restarting nodes
* `E2E_AUDIT_ENABLED` & `E2E_AUDIT_SCORING_ENABLED` are toggling audits as expected.
* Only abnormality experienced was in regards to a node being selected for reward which was updating the Node's score and disrupting local testing.

# Pending Action Items:
* [x] 1. Prod CRDB Table migration to add `verify_e2e_passed_at` & `verify_e2e_failed_at` fields
* [x] 4. Test Failure scenarios at both: 1) Proof submission, 2) Proof Retrieval Consumer step, 3) Proof Verification consumer step and assert that audit score decrements appropriately. (For 2/3: Test complete proof failure path, For 1/2/3: Test failure of first 'n' attempts and successful third attempt)
* [x] 2. Resolve merge conflicts
* [x] 3. Resque-Scheduler Research (Notes & Summary of my findings below)

I've included my notes below. After doing research the Scheduler will run on multiple instances, but provides an easy way to check if an instance is currently elected as leader/master. I don't think we need to worry about the Scheduler running on multiple instances given that we are ONLY using `Delayed Jobs`. Checking if a particular node is elected master before queuing a job seems to be only applicable towards `Scheduled or Dynamically Scheduled Jobs`

```
- This project implements the "scheduler" part of rescue-scheduler (the daemon which can promote enqueued delayed jobs into the work queues when it is time), but not the CRON scheduler proxy. To learn more about how to use a CRON-like scheduler, read the Job Schedules section of this document.
- From the "Failed Worker Management" Section: By default, the scheduler will check for workers which haven't pinged redis in 60 minutes. If this happens, we will assume the process crashed, and remove it from redis. If this worker was working on a job, we will place it in the failed queue for later inspection.
- `NOTE:` Assuming you are running node-resque across multiple machines, you will need to ensure that only one of your processes is actually scheduling the jobs. To help you with this, you can inspect which of the scheduler processes is currently acting as master, and flag only the master scheduler process to run the schedule.
- Code example of enqueing a job only on a Scheduler master node...
```
```
const scheduler = new NodeResque.Scheduler({connection: connectionDetails});
await scheduler.connect()
scheduler.start()


schedule.scheduleJob('10,20,30,40,50 * * * * *', async () => { // do this job every 10 seconds, CRON style
  // we want to ensure that only one instance of this job is scheduled in our environment at once,
  // no matter how many schedulers we have running
  if(scheduler.master){
    console.log(">>> enquing a job");
    await queue.enqueue('time', "ticktock", new Date().toString() );
  }
});
```
```
- Node-Resque package aims to be fully compatible with Ruby's Resque and implementations of Resque Scheduler

Resque-Scheduler (Ruby) Notes:
- Electing a master and failover is built in and default. Simply run resque-scheduler on as many machine as you want pointing to the same redis instance and schedule.
- The scheduler processes will use redis to elect a master process and detect failover when the master dies.
```


# Testing:
Parameters
* 5 Chainpoint Nodes all starting with a blank slate and a score of `1000`
* Trigger E2E Audit every two minutes
* Enqueue delay 35 Seconds between every consumer step

### Case 1: 
At every step of the audit (submission, retrieval, verification), fail the first two attempts, then pass third attempt.

Step 1. Fail twice on Hash Submission, then restart Chainpoint Node so it can return a Proof Handle
Step 2. Fail twice on Hash Retrieval from Node, then restart Chainpoint Node so it can return a Proof
Step 3. Fail twice on Hash Verification from Node, then restart Chainpoint Node so it can verify a Proof

Result: PASSED